### PR TITLE
Bdog 502

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val library = Project(name, file("."))
     publishAndDistribute := {},
 
     // by default this is Seq(scalaVersion) which doesn't play well and causes sbt
-    // to try to an invalid cross-build for hmrcMongoMetrixPlay27
+    // to try an invalid cross-build for hmrcMongoMetrixPlay27
     crossScalaVersions := Seq.empty
   )
   .aggregate(
@@ -46,7 +46,7 @@ lazy val hmrcMongoCommon = Project("hmrc-mongo-common", file("hmrc-mongo-common"
   .enablePlugins(SbtAutoBuildPlugin, SbtArtifactory)
   .settings(
     commonSettings,
-    libraryDependencies ++= AppDependencies.mongoCommon
+    libraryDependencies ++= AppDependencies.mongoCommon(scalaBinaryVersion.value)
   )
 
 lazy val hmrcMongoPlay26 = Project("hmrc-mongo-play-26", file("hmrc-mongo-play-26"))

--- a/hmrc-mongo-metrix-play-26/src/main/scala/uk/gov/hmrc/mongo/metrix/MetricOrchestrator.scala
+++ b/hmrc-mongo-metrix-play-26/src/main/scala/uk/gov/hmrc/mongo/metrix/MetricOrchestrator.scala
@@ -83,13 +83,9 @@ class MetricOrchestrator(
                        case None => Future(Map.empty[String, Int])
                      }
       mapFromSources <- Future.traverse(metricSources)(_.metrics)
-      mapToPersist = (mapFromReset :: mapFromSources) reduce {
-        _ ++ _
-      }
+      mapToPersist = (mapFromReset :: mapFromSources).reduce(_ ++ _)
       metricsToPersist = mapToPersist.map { case (name: String, value: Int) => PersistedMetric(name, value) }.toList
-      _ <- Future.traverse(metricsToPersist) { m =>
-            metricRepository.persist(m)
-          }
+      _ <- Future.traverse(metricsToPersist)(metricRepository.persist)
     } yield mapToPersist
 
   private def ensureMetricRegistered(persistedMetrics: List[PersistedMetric]): Unit = {

--- a/hmrc-mongo-metrix-play-26/src/main/scala/uk/gov/hmrc/mongo/metrix/MongoMetricRepository.scala
+++ b/hmrc-mongo-metrix-play-26/src/main/scala/uk/gov/hmrc/mongo/metrix/MongoMetricRepository.scala
@@ -52,16 +52,16 @@ class MongoMetricRepository @Inject() (
   override def findAll(): Future[List[PersistedMetric]] =
     collection.withReadPreference(ReadPreference.secondaryPreferred)
       .find()
-      .toThrottledFuture()
+      .toFuture()
       .map(_.toList)
 
   override def persist(calculatedMetric: PersistedMetric): Future[Unit] =
     collection
       .findOneAndReplace(
-        filter = equal("name", calculatedMetric.name),
-        calculatedMetric,
-        FindOneAndReplaceOptions().upsert(true)
+        filter      = equal("name", calculatedMetric.name),
+        replacement = calculatedMetric,
+        options     = FindOneAndReplaceOptions().upsert(true)
       )
-      .toThrottledFutureOption()
+      .toFutureOption()
       .map(_ => ())
 }

--- a/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/play/json/Codecs.scala
+++ b/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/play/json/Codecs.scala
@@ -20,7 +20,7 @@ import org.bson._
 import org.bson.codecs.{BsonTypeCodecMap, Codec, DecoderContext, EncoderContext}
 import org.bson.json.{JsonMode, JsonReader, JsonWriter, JsonWriterSettings}
 import org.bson.types.Decimal128
-import org.mongodb.scala.bson.codecs.DEFAULT_CODEC_REGISTRY
+import org.mongodb.scala.MongoClient.DEFAULT_CODEC_REGISTRY
 import org.slf4j.{Logger, LoggerFactory}
 import play.api.libs.json._
 import org.mongodb.scala.{Document => ScalaDocument}
@@ -143,7 +143,8 @@ trait Codecs {
     // wrap value in a document inorder to reuse the document -> JsonString, then extract
     val writer = new java.io.StringWriter
     val doc    = new BsonDocument("tempKey", bs)
-    bsonDocumentCodec.encode(new JsonWriter(writer, new JsonWriterSettings(mode)), doc, EncoderContext.builder.build)
+    val writerSettings = JsonWriterSettings.builder.outputMode(mode).build
+    bsonDocumentCodec.encode(new JsonWriter(writer, writerSettings), doc, EncoderContext.builder.build)
     Json.parse(writer.toString) \ "tempKey"
   }
 

--- a/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/play/json/CollectionFactory.scala
+++ b/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/play/json/CollectionFactory.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.mongo.play.json
 
 import org.bson.codecs.configuration.CodecRegistries
-import org.mongodb.scala.bson.codecs.DEFAULT_CODEC_REGISTRY
 import org.mongodb.scala.{MongoCollection, MongoDatabase}
+import org.mongodb.scala.MongoClient.DEFAULT_CODEC_REGISTRY
 import play.api.libs.json.Format
 
 import scala.reflect.ClassTag

--- a/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/throttle/ThrottledCollection.scala
+++ b/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/throttle/ThrottledCollection.scala
@@ -31,7 +31,7 @@ class ThrottleConfig @Inject()(configuration: Configuration) {
   val maxWaitQueueSize = {
     val mongoUri = configuration.get[String]("mongodb.uri")
     val client = MongoClient(uri = mongoUri)
-    client.settings.getConnectionPoolSettings.getMaxWaitQueueSize
+    1000//client.settings.getConnectionPoolSettings.getMaxWaitQueueSize // TODO
   }
 
   /** size should be no larger than the WaitQueueSize (default size is 500)

--- a/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/throttle/ThrottledCollection.scala
+++ b/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/throttle/ThrottledCollection.scala
@@ -28,17 +28,8 @@ import scala.concurrent.duration.{Duration, DurationInt}
 @Singleton
 class ThrottleConfig @Inject()(configuration: Configuration) {
 
-  val maxWaitQueueSize = {
-    val mongoUri = configuration.get[String]("mongodb.uri")
-    val client = MongoClient(uri = mongoUri)
-    1000//client.settings.getConnectionPoolSettings.getMaxWaitQueueSize // TODO
-  }
-
-  /** size should be no larger than the WaitQueueSize (default size is 500)
-    * larger than this will cause `com.mongodb.MongoWaitQueueFullException: Too many operations are already waiting for a connection. Max number of operations (maxWaitQueueSize) of 500 has been exceeded.`
-    */
   val throttleSize =
-    configuration.getOptional[Int]("mongodb.throttle.size").getOrElse(maxWaitQueueSize)
+    configuration.get[Int]("mongodb.throttle.size")
 
   Logger.debug(s"Throttling mongo queries using throttleSize=$throttleSize")
 

--- a/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/throttle/ThrottledCollection.scala
+++ b/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/throttle/ThrottledCollection.scala
@@ -29,6 +29,7 @@ import scala.concurrent.duration.{Duration, DurationInt}
 class ThrottleConfig @Inject()(configuration: Configuration) {
 
   val throttleSize =
+    // the default size of 500 is based on the default WaitQueueSize, which mongo previously used.
     configuration.getOptional[Int]("mongodb.throttle.size").getOrElse(500)
 
   Logger.debug(s"Throttling mongo queries using throttleSize=$throttleSize")

--- a/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/throttle/ThrottledCollection.scala
+++ b/hmrc-mongo-play-26/src/main/scala/uk/gov/hmrc/mongo/throttle/ThrottledCollection.scala
@@ -53,7 +53,7 @@ trait WithThrottling {
 
   // the following overrides of `toFuture` ensure that the observables are evaluated on the throttled thread-pool.
 
-  object ObservableImplicits extends org.mongodb.scala.ObservableImplicits
+  private object ObservableImplicits extends org.mongodb.scala.ObservableImplicits
 
   implicit class SingleObservableFuture[T](observable: => SingleObservable[T])(implicit ec: ExecutionContext) {
     def toFuture(): Future[T] =

--- a/hmrc-mongo-play-26/src/test/scala/uk/gov/hmrc/mongo/play/json/PlayMongoCollectionSpec.scala
+++ b/hmrc-mongo-play-26/src/test/scala/uk/gov/hmrc/mongo/play/json/PlayMongoCollectionSpec.scala
@@ -22,7 +22,6 @@ import com.mongodb.MongoWriteException
 import org.bson.types.ObjectId
 import org.joda.{time => jot}
 import org.mongodb.scala.bson.{BsonDocument, BsonString}
-import org.mongodb.scala.Completed
 import org.mongodb.scala.model.{Filters, Updates}
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.compatible.Assertion
@@ -79,7 +78,7 @@ class PlayMongoRepositorySpec
         prepareDatabase()
 
         val result = playMongoRepository.collection.insertOne(myObj).toFuture
-        result.futureValue shouldBe Completed()
+        result.futureValue.wasAcknowledged shouldBe true
 
         val writtenObj = playMongoRepository.collection.find().toFuture
         writtenObj.futureValue shouldBe List(myObj)
@@ -91,7 +90,7 @@ class PlayMongoRepositorySpec
         prepareDatabase()
 
         val result = playMongoRepository.collection.insertOne(myObj).toFuture
-        result.futureValue shouldBe Completed()
+        result.futureValue.wasAcknowledged shouldBe true
 
         def checkFind[A: Writes](key: String, value: A): Assertion =
           playMongoRepository.collection
@@ -123,7 +122,7 @@ class PlayMongoRepositorySpec
           prepareDatabase()
 
           val result = playMongoRepository.collection.insertOne(originalObj).toFuture
-          result.futureValue shouldBe Completed()
+          result.futureValue.wasAcknowledged shouldBe true
 
           def checkUpdate[A: Writes](key: String, value: A): Assertion =
             playMongoRepository.collection
@@ -160,7 +159,7 @@ class PlayMongoRepositorySpec
           prepareDatabase()
 
           val result = playMongoRepository.collection.insertOne(originalObj).toFuture
-          result.futureValue shouldBe Completed()
+          result.futureValue.wasAcknowledged shouldBe true
 
           def checkUpdateFails[A](key: String, value: A)(implicit ev: Writes[A]): Assertion =
             whenReady {

--- a/hmrc-mongo-test-play-26/src/main/scala/uk/gov/hmrc/mongo/test/PlayMongoRepositorySupport.scala
+++ b/hmrc-mongo-test-play-26/src/main/scala/uk/gov/hmrc/mongo/test/PlayMongoRepositorySupport.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.mongo.test
 
-import org.mongodb.scala.Completed
 import org.mongodb.scala.bson.BsonDocument
 import org.mongodb.scala.bson.conversions.Bson
 import org.mongodb.scala.model.IndexModel
+import org.mongodb.scala.result.InsertOneResult
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.MongoUtils
 
@@ -62,7 +62,7 @@ trait PlayMongoRepositorySupport[A] extends MongoSupport {
       .find(filter)
       .toFuture
 
-  protected def insert(a: A): Future[Completed] =
+  protected def insert(a: A): Future[InsertOneResult] =
     repository.collection
       .insertOne(a)
       .toFuture

--- a/hmrc-mongo-test-play-26/src/test/scala/uk/gov/hmrc/mongo/throttle/WithThrottlingSpec.scala
+++ b/hmrc-mongo-test-play-26/src/test/scala/uk/gov/hmrc/mongo/throttle/WithThrottlingSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.mongo.throttle
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import play.api.Configuration
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+
+class WithThrottlingSpec extends AnyWordSpecLike with Matchers with ScalaFutures {
+
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(60.seconds)
+
+  "WithThrottling.throttling" should {
+
+    "not exceed throttleSize" in {
+      val throttleSize = 2
+      val config = new ThrottleConfig(Configuration("mongodb.throttle.size" -> throttleSize))
+      // a def, since it shouldn't matter how many WithThrottling we use, as long as we have one config.
+      def throttle = new WithThrottling {
+        override def throttleConfig = config
+      }
+
+      val counter = new java.util.concurrent.atomic.AtomicInteger()
+
+      val range = 1 to 100
+
+      Future.traverse(range) { _ =>
+        throttle.throttling(counter){ counter =>
+          Future {
+            val count = counter.incrementAndGet
+            if (count > throttleSize) sys.error(s"Count $count exceeded $throttleSize")
+            Thread.sleep(100)
+            counter.getAndDecrement
+            ()
+          }
+        }
+      }.futureValue shouldBe range.map(_ => ())
+    }
+  }
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -13,10 +13,12 @@ object AppDependencies {
     "ch.qos.logback"       % "logback-classic"           % "1.2.3"        % Test,
   )
 
-  lazy val mongoCommon: Seq[ModuleID] = Seq(
+  def mongoCommon(scalaBinaryVersionValue: String): Seq[ModuleID] = Seq(
     "org.mongodb.scala" %% "mongo-scala-driver" % "4.0.0-rc0"
-       exclude(org = "org.mongodb.scala", name = "bson-scala_2.11")
-       exclude(org = "org.mongodb.scala", name = "bson-scala_2.12"), // TODO exclude for all scala versions...
+      // mongodb has a non-existant dependency, which isn't needed, and will fail to download.
+      // this may be redundant in a future version.
+      // excludeAll("org.mongodb.scala" %% "bson-scala") not excluding for scala binary version appropriately...
+      excludeAll("org.mongodb.scala" % s"bson-scala_$scalaBinaryVersionValue"),
     "org.slf4j"         %  "slf4j-api"          % "1.7.30"
   )
 
@@ -26,34 +28,34 @@ object AppDependencies {
   lazy val hmrcMongoPlay26: Seq[ModuleID] = Seq(
     "com.typesafe.play" %% "play"       % play26Version,
     "com.typesafe.play" %% "play-guice" % play26Version,
-  ) ++ mongoCommon ++ test
+  ) ++ test
 
   lazy val hmrcMongoPlay27: Seq[ModuleID] = Seq(
     "com.typesafe.play" %% "play"       % play27Version,
     "com.typesafe.play" %% "play-guice" % play27Version,
-  ) ++ mongoCommon ++ test
+  ) ++ test
 
-  lazy val hmrcMongoCachePlay26: Seq[ModuleID] = Seq() ++ mongoCommon ++ test
+  lazy val hmrcMongoCachePlay26: Seq[ModuleID] = Seq() ++ test
 
   lazy val hmrcMongoTestPlay26: Seq[ModuleID] = Seq(
     "com.vladsch.flexmark"  %  "flexmark-all"    % "0.35.10",
     "org.scalatest"         %% "scalatest"       % "3.1.0",
     "org.mockito"           %% "mockito-scala"   % "1.10.1" % Test
-  ) ++ mongoCommon ++ hmrcMongoPlay26 ++ test
+  ) ++ test
 
   lazy val hmrcMongoTestPlay27: Seq[ModuleID] = Seq(
     "com.vladsch.flexmark"  %  "flexmark-all"    % "0.35.10",
     "org.scalatest"         %% "scalatest"       % "3.1.0",
     "org.mockito"           %% "mockito-scala"   % "1.10.1" % Test
-  ) ++ mongoCommon ++ hmrcMongoPlay27 ++ test
+  ) ++ test
 
   lazy val hmrcMongoMetrixPlay26: Seq[ModuleID] = Seq(
     "com.kenshoo"           %% "metrics-play"    % "2.6.19_0.7.0",
     "org.mockito"           %% "mockito-scala"   % "1.10.1" % Test
-  ) ++ hmrcMongoPlay26 ++ metrixCommon
+  )
 
   lazy val hmrcMongoMetrixPlay27: Seq[ModuleID] = Seq(
     "com.kenshoo"           %% "metrics-play"    % "2.7.3_0.8.1",
     "org.mockito"           %% "mockito-scala"   % "1.10.1" % Test
-  ) ++ hmrcMongoPlay27 ++ metrixCommon
+  )
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -14,7 +14,9 @@ object AppDependencies {
   )
 
   lazy val mongoCommon: Seq[ModuleID] = Seq(
-    "org.mongodb.scala" %% "mongo-scala-driver" % "2.8.0",
+    "org.mongodb.scala" %% "mongo-scala-driver" % "4.0.0-rc0"
+       exclude(org = "org.mongodb.scala", name = "bson-scala_2.11")
+       exclude(org = "org.mongodb.scala", name = "bson-scala_2.12"), // TODO exclude for all scala versions...
     "org.slf4j"         %  "slf4j-api"          % "1.7.30"
   )
 


### PR DESCRIPTION
Update to latest mongo-driver which allows us to provide our throttling behaviour by overriding the default `toFuture`, `toFutureOption` functions.