### PR TITLE
Remove cyclical dependency between LockService and LockRepository

### DIFF
--- a/hmrc-mongo-metrix-play-27/README.md
+++ b/hmrc-mongo-metrix-play-27/README.md
@@ -1,18 +1,18 @@
 
 # metrix
 
-Metrix is a library to help with [Dropwizard](https://metrics.dropwizard.io) metric collection across a multi-node system, 
-when you only want one node to do the data gathering. This can help with slow metric reporting, so that only one node is 
+Metrix is a library to help with [Dropwizard](https://metrics.dropwizard.io) metric collection across a multi-node system,
+when you only want one node to do the data gathering. This can help with slow metric reporting, so that only one node is
 doing the slow-running action.
 
-It does this by using a backing Mongo persistence store that is shared across all nodes, using `mongo-lock` to ensure 
+It does this by using a backing Mongo persistence store that is shared across all nodes, using `mongo-lock` to ensure
 that only one node can write the metrics.
 
-All nodes then periodically refresh an internal cache of the metrics from the persisted collection. 
+All nodes then periodically refresh an internal cache of the metrics from the persisted collection.
 
-Ultimately, the custom metrics collected via this library are all stored as a [Gauge[Int]](https://metrics.dropwizard.io/3.1.0/getting-started/#gauges) 
-in the normal Dropwizard metric registries, meaning that they will be treated the same way as any other metrics you are 
-collecting, and will be shipped out by whatever method you are using. 
+Ultimately, the custom metrics collected via this library are all stored as a [Gauge[Int]](https://metrics.dropwizard.io/3.1.0/getting-started/#gauges)
+in the normal Dropwizard metric registries, meaning that they will be treated the same way as any other metrics you are
+collecting, and will be shipped out by whatever method you are using.
 
 > In DropWizard, a gauge is an instantaneous measurement of a value. They implemented a single method interface, which is just:
 > `T getValue();`
@@ -28,11 +28,11 @@ There is a single method to be implemented to gather metrics, in `MetricSource`:
 def metrics(implicit ec: ExecutionContext): Future[Map[String, Int]]
 ```
 
-All nodes periodically try to acquire the lock. As seen on the above picture after one of the nodes manages to acquire the 
+All nodes periodically try to acquire the lock. As seen on the above picture after one of the nodes manages to acquire the
 lock, it will gather the data through predefined classes that implement the MetricSource trait, and write it to the datastore.
 The lock is needed as the metric gathering might be a resource and time heavy operation.
 
-All the nodes will also periodically get all the metrics and update their local MetricCache. The mongo lock is not needed 
+All the nodes will also periodically get all the metrics and update their local MetricCache. The mongo lock is not needed
 for this operation. They also control the creation and registration of individual CachedGaguges which are tied with the standard metric reporting mechanism. They would typically read values from MetricCache whenever asked for it. See below for details.
 
 ## How reporting works
@@ -41,10 +41,10 @@ for this operation. They also control the creation and registration of individua
 
 There is a CacheGauge registered in the MetricRegistry for each metric gathered from metric sources.
 
-Graphite reporter is will run on a regular (configured) basis and retrieve all registered Gaguges, calling the 
+Graphite reporter is will run on a regular (configured) basis and retrieve all registered Gaguges, calling the
 getValue() method on each of them.
 
-The CacheGauges will then read the value for a given metric from the MetricCache and return it. GraphiteReporter will pass 
+The CacheGauges will then read the value for a given metric from the MetricCache and return it. GraphiteReporter will pass
 this information to graphite.
 
 ## Example construction
@@ -54,7 +54,7 @@ import scala.concurrent.duration.DurationInt
 
 val lockId: String                            = "your-lock-id"
 val ttl: Duration                             = 10.seconds
-val mongoLockService                          = mongoLockRepository.toService(lockId, ttl)
+val mongoLockService                          = MongoLockService(mongoLockRepository, lockId, ttl)
 
 val sources: List[MetricSource] = ... AddYourMetricSourcesHere ...
 
@@ -65,11 +65,11 @@ val metricOrchestrator new MetricOrchestrator(
   metricRegistry    = metricRegistry
 )
 ```
-## Example usage    
+## Example usage
 ``` scala
 metricOrchestrator.attemptMetricRefresh().map(_.andLogTheResult())
     .recover { case e: RuntimeException => Logger.error(s"An error occurred processing metrics: ${e.getMessage}", e) }
-```      
+```
 
 There are two filters of the form `(PersistedMetric => Boolean)` you can pass to the `attemptMetricRefresh` function:
 
@@ -77,21 +77,20 @@ There are two filters of the form `(PersistedMetric => Boolean)` you can pass to
  * resetToZeroFor   => Set a particular metric to zero (reset it)
 
 ## Installing
- 
+
 Metrix is now part of and versioned with the `hmrc-mongo` library, which provides helper utilities for building systems with mongo.
- 
+
 Include the following dependency in your SBT build
- 
+
 ``` scala
 resolvers += Resolver.bintrayRepo("hmrc", "releases")
- 
-libraryDependencies += "uk.gov.hmrc" %% "hmrc-mongo-metrix-play-26" % "[INSERT-VERSION]" 
+
+libraryDependencies += "uk.gov.hmrc.mongo" %% "hmrc-mongo-metrix-play-26" % "[INSERT-VERSION]"
 ```
 ## Compatibility
-Metrix uses the official [mongo-scala](https://mongodb.github.io/mongo-scala-driver/) driver, instead of [ReactiveMongo](https://github.com/ReactiveMongo/ReactiveMongo) 
-which was used in [previous (now deprecated) releases](https://github.com/hmrc/metrix) under the `metrix` (instead of `hmrc-mongo-metrix`) artifact ID. 
+Metrix uses the official [mongo-scala](https://mongodb.github.io/mongo-scala-driver/) driver, instead of [ReactiveMongo](https://github.com/ReactiveMongo/ReactiveMongo)
+which was used in [previous (now deprecated) releases](https://github.com/hmrc/metrix) under the `metrix` (instead of `hmrc-mongo-metrix`) artifact ID.
 
 ### License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").
-    

--- a/hmrc-mongo-play-27/src/main/scala/uk/gov/hmrc/mongo/lock/MongoLockRepository.scala
+++ b/hmrc-mongo-play-27/src/main/scala/uk/gov/hmrc/mongo/lock/MongoLockRepository.scala
@@ -41,9 +41,6 @@ trait LockRepository {
 
   def isLocked(lockId: String, owner: String): Future[Boolean]
 
-  def toService(lockId: String, ttl: Duration) =
-    MongoLockService(this, lockId, ttl)
-
   def attemptLockWithRelease[T](lockId: String, owner: String, ttl: Duration, body: => Future[T])(
     implicit ec: ExecutionContext
   ): Future[Option[T]] = {

--- a/hmrc-mongo-play-27/src/main/scala/uk/gov/hmrc/mongo/lock/MongoLockService.scala
+++ b/hmrc-mongo-play-27/src/main/scala/uk/gov/hmrc/mongo/lock/MongoLockService.scala
@@ -38,11 +38,12 @@ trait MongoLockService {
 
 object MongoLockService {
 
-  def apply(repository: LockRepository, lock: String, duration: Duration): MongoLockService =
+  def apply(lockRepository: LockRepository, lockId: String, ttl: Duration): MongoLockService = {
+    val (lockRepository1, lockId1, ttl1) = (lockRepository, lockId, ttl)
     new MongoLockService {
-      override val lockRepository: LockRepository = repository
-      override val lockId: String                 = lock
-      override val ttl: Duration                  = duration
+      override val lockRepository: LockRepository = lockRepository1
+      override val lockId        : String         = lockId1
+      override val ttl           : Duration       = ttl1
     }
-
+  }
 }

--- a/hmrc-mongo-test-play-27/src/test/scala/uk/gov/hmrc/mongo/lock/MongoLockServiceSpec.scala
+++ b/hmrc-mongo-test-play-27/src/test/scala/uk/gov/hmrc/mongo/lock/MongoLockServiceSpec.scala
@@ -115,8 +115,7 @@ class MongoLockServiceSpec
 
     "not execute the body and exit if the lock for another serverId exists" in {
       var counter = 0
-      repository
-        .toService(lockId, ttl)
+      MongoLockService(repository, lockId, ttl)
         .attemptLockWithRefreshExpiry {
           Future.successful(counter += 1)
         }
@@ -151,5 +150,5 @@ class MongoLockServiceSpec
   private val now           = Instant.now()
 
   override protected val repository = new MongoLockRepository(mongoComponent, new CurrentTimestampSupport)
-  private val mongoLockService    = repository.toService(lockId, ttl)
+  private val mongoLockService      = MongoLockService(repository, lockId, ttl)
 }


### PR DESCRIPTION
Removes the `repository.toService` function which created a cyclical dependency and made mocking difficult. It also aligns it with the Metrics API.