### PR TITLE
Add support for Mongo generic binary data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ dist
 .metals/
 .vscode/
 .bloop/
+.bsp/
 metals.sbt

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -301,6 +301,12 @@ collection.findOneAndUpdate(
 
 Dates are worth a special mention. Codecs are already provided for Java time, allowing their use directly in filters/updates. However, they do not exist for jodatime, you will have to use `Codecs.toBson` with the `uk.gov.hmrc.mongo.play.json.formats.MongoJodaFormats` in scope. We recommend migrating to use java time.
 
+#### Binary data
+
+Play framework already provides formats for encoding `Array[Byte]`. However, these formats are provided via the generic format for arrays, and therefore encode byte arrays as arrays of numbers.
+
+This is not what most services require when encoding binary data to store in Mongo, so **hmrc-mongo** provides `uk.gov.hmrc.mongo.play.json.formats.MongoBinaryFormats` for encoding `Array[Byte]`, `ByteBuffer` and `akka.util.ByteString` to Mongo's binary representation.
+
 #### Nothing
 
 If you come across:

--- a/hmrc-mongo-play-27/src/main/scala/uk/gov/hmrc/mongo/play/json/formats/MongoBinaryFormats.scala
+++ b/hmrc-mongo-play-27/src/main/scala/uk/gov/hmrc/mongo/play/json/formats/MongoBinaryFormats.scala
@@ -1,0 +1,59 @@
+package uk.gov.hmrc.mongo.play.json.formats
+
+import akka.util.ByteString
+import org.bson.BsonBinarySubType
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+import java.nio.ByteBuffer
+import java.util.Base64
+
+trait MongoBinaryFormats {
+  outer =>
+
+  private val encoder = Base64.getEncoder
+  private val decoder = Base64.getDecoder
+
+  private val GenericBinarySubtype = BsonBinarySubType.BINARY.getValue
+
+  final val byteArrayReads: Reads[Array[Byte]] =
+    Reads
+      .at[String](__ \ "$binary" \ "subType")
+      .map(_.toByte)
+      .flatMap {
+        case `GenericBinarySubtype` =>
+          Reads
+            .at[String](__ \ "$binary" \ "base64")
+            .map(decoder.decode)
+        case other =>
+          Reads.failed(f"Invalid BSON binary subtype for generic binary data: '$other%02x'")
+      }
+
+  final val byteArrayWrites: Writes[Array[Byte]] = Writes { bytes =>
+    Json.obj(
+      "$binary" -> Json.obj(
+        "base64"  -> encoder.encodeToString(bytes),
+        "subType" -> f"$GenericBinarySubtype%02x"
+      )
+    )
+  }
+
+  final val byteArrayFormat: Format[Array[Byte]] =
+    Format(byteArrayReads, byteArrayWrites)
+
+  final val byteBufferFormat: Format[ByteBuffer] =
+    byteArrayFormat.inmap(ByteBuffer.wrap, _.array())
+
+  final val byteStringFormat: Format[ByteString] =
+    byteArrayFormat.inmap(ByteString.apply, _.toArray[Byte])
+
+  trait Implicits {
+    implicit val byteArrayFormat: Format[Array[Byte]] = outer.byteArrayFormat
+    implicit val byteBufferFormat: Format[ByteBuffer] = outer.byteBufferFormat
+    implicit val byteStringFormat: Format[ByteString] = outer.byteStringFormat
+  }
+
+  object Implicits extends Implicits
+}
+
+object MongoBinaryFormats extends MongoBinaryFormats

--- a/hmrc-mongo-play-27/src/main/scala/uk/gov/hmrc/mongo/play/json/formats/MongoBinaryFormats.scala
+++ b/hmrc-mongo-play-27/src/main/scala/uk/gov/hmrc/mongo/play/json/formats/MongoBinaryFormats.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.mongo.play.json.formats
 
 import akka.util.ByteString

--- a/hmrc-mongo-play-27/src/test/scala/uk/gov/hmrc/mongo/play/json/PlayMongoRepositorySpec.scala
+++ b/hmrc-mongo-play-27/src/test/scala/uk/gov/hmrc/mongo/play/json/PlayMongoRepositorySpec.scala
@@ -384,6 +384,8 @@ object PlayMongoRepositorySpec {
     // UUID
     uuid             : UUID,
     uuidWrapper      : UUIDWrapper,
+    // Binary data - we use ByteString for this test because case class equality
+    // uses reference equality for arrays so it will never compare equal
     binary           : ByteString,
     binaryWrapper    : BinaryWrapper
   )


### PR DESCRIPTION
By default Play JSON encodes `Array[Byte]` using the generic array format, which just produces arrays of numbers:

![image](https://user-images.githubusercontent.com/2992938/135457621-f18e1813-fc82-4cc5-9301-adf44b44f53d.png)

This PR adds formats for encoding `Array[Byte]`, `nio.ByteBuffer` and `akka.util.ByteString` as binary data using the generic binary subtype.