### PR TITLE
Correct work-item-repo HOW_TO_USE link

### DIFF
--- a/hmrc-mongo-work-item-repo-play-30/README.md
+++ b/hmrc-mongo-work-item-repo-play-30/README.md
@@ -20,7 +20,7 @@ Where `play-xx` is your version of Play (e.g. `play-28`).
 
 ## How to Use
 
-See [How to Use](https://github.com/hmrc/hmrc-mongo/tree/main/hmrc-mongo-work-item-repo-play-28/HOW_TO_USE.md)
+See [How to Use](./HOW_TO_USE.md)
 
 ### License
 


### PR DESCRIPTION
Previously pointed specifically at play-28. Now should just point to the HOW_TO_USE.md file in whatever folder README.md is in.